### PR TITLE
Fix API call in petition templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/appearancemodifier/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-08-08</releaseDate>
-    <version>3.0.5</version>
+    <releaseDate>2021-08-09</releaseDate>
+    <version>3.0.6</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/templates/CRM/Appearancemodifier/Petition/signature.tpl
+++ b/templates/CRM/Appearancemodifier/Petition/signature.tpl
@@ -1,4 +1,4 @@
-{crmAPI var="modifiedPetition" entity="AppearancemodifierPetition" action="get" version="3" uf_group_id=$survey_id}
+{crmAPI var="modifiedPetition" entity="AppearancemodifierPetition" action="get" version="3" survey_id=$survey_id}
 {if $modifiedPetition.count eq '1' && isset($modifiedPetition.values[0].background_color)}
     {assign var=backgroundColor value=$modifiedPetition.values[0].background_color}
     {include file="CRM/Appearancemodifier/background.css.tpl"}

--- a/templates/CRM/Appearancemodifier/Petition/thankyou.tpl
+++ b/templates/CRM/Appearancemodifier/Petition/thankyou.tpl
@@ -1,4 +1,4 @@
-{crmAPI var="modifiedPetition" entity="AppearancemodifierPetition" action="get" version="3" uf_group_id=$survey_id}
+{crmAPI var="modifiedPetition" entity="AppearancemodifierPetition" action="get" version="3" survey_id=$survey_id}
 {if $modifiedPetition.count eq '1' && isset($modifiedPetition.values[0].background_color)}
     {assign var=backgroundColor value=$modifiedPetition.values[0].background_color}
     {include file="CRM/Appearancemodifier/background.css.tpl"}


### PR DESCRIPTION
It resolves #14. Could be tracked if the first petition does not have color, the second one does have
and we are checking the public page of the second one. The api call was successful and the first item
params were used instead of the second one.