### PR TITLE
Force templates to use the extension translations

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/appearancemodifier/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-11-01</releaseDate>
-    <version>3.3.0</version>
+    <releaseDate>2021-11-04</releaseDate>
+    <version>3.3.1</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/templates/CRM/Appearancemodifier/Form/Event.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Event.tpl
@@ -1,3 +1,4 @@
+{crmScope extensionKey='appearancemodifier'}
 <div class="crm-block crm-form-block">
     <table class="form-layout">
         <tr>
@@ -68,3 +69,4 @@
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>
+{/crmScope}

--- a/templates/CRM/Appearancemodifier/Form/Petition.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Petition.tpl
@@ -1,3 +1,4 @@
+{crmScope extensionKey='appearancemodifier'}
 <div class="crm-block crm-form-block">
     <table class="form-layout">
         <tr>
@@ -87,3 +88,4 @@
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>
+{/crmScope}

--- a/templates/CRM/Appearancemodifier/Form/Profile.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Profile.tpl
@@ -1,3 +1,4 @@
+{crmScope extensionKey='appearancemodifier'}
 <div class="crm-block crm-form-block">
     <table class="form-layout">
         <tr>
@@ -62,3 +63,4 @@
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>
+{/crmScope}

--- a/templates/CRM/Appearancemodifier/Petition/signersnumber.tpl
+++ b/templates/CRM/Appearancemodifier/Petition/signersnumber.tpl
@@ -1,3 +1,5 @@
+{crmScope extensionKey='appearancemodifier'}
 <div class="appearancemodifier-signers-number">
     <p>{ts 1=$numberOfSigners}Already signed by %1 people.{/ts}</p>
 </div>
+{/crmScope}

--- a/templates/CRM/Appearancemodifier/Petition/signersprogressbar.tpl
+++ b/templates/CRM/Appearancemodifier/Petition/signersprogressbar.tpl
@@ -1,4 +1,6 @@
+{crmScope extensionKey='appearancemodifier'}
 <div class="appearancemodifier-signers-progressbar">
     <p>{ts 1=$numberOfSigners 2=$targetNumberOfSigners}Already signed by %1 people. Let's make %2 signatures!{/ts}</p>
     <progress value="{$numberOfSigners}" max="{$targetNumberOfSigners}"></progress>
 </div>
+{/crmScope}


### PR DESCRIPTION
Translation issues were reported on the petition form. The text in the number of signers block wasn't translated. As it turned out the scope definition were missing from the template files. 