### PR TITLE
Hide form title option

### DIFF
--- a/CRM/Appearancemodifier/Form/AbstractBase.php
+++ b/CRM/Appearancemodifier/Form/AbstractBase.php
@@ -101,6 +101,7 @@ abstract class CRM_Appearancemodifier_Form_AbstractBase extends CRM_Core_Form
         $this->add('checkbox', 'add_placeholder', E::ts('Add placeholders'), [], false);
         $this->add('color', 'font_color', E::ts('Font Color'), [], false);
         $this->add('checkbox', 'original_font_color', E::ts('Original Font Color'), [], false);
+        $this->add('checkbox', 'hide_form_title', E::ts('Hide form title'), [], false);
         // If the consentactivity extension is installed, the custom consent field -> activity mapping has to be provided
         // defaults for the consentactivity extension related config.
         if (count($this->consentFieldNames) > 0) {

--- a/CRM/Appearancemodifier/Form/AbstractBase.php
+++ b/CRM/Appearancemodifier/Form/AbstractBase.php
@@ -63,6 +63,26 @@ abstract class CRM_Appearancemodifier_Form_AbstractBase extends CRM_Core_Form
     }
 
     /**
+     * This function sets the default values for the fields that are present
+     * in the customization.
+     *
+     * @param array $customFormData the entity data.
+     * @param array $variables the custom data.
+     *
+     * @throws CRM_Core_Exception
+     */
+    protected function customDefaultValues(array $customFormData, array $variables): void
+    {
+        if ($customFormData['custom_settings'] !== null) {
+            foreach ($variables as $key => $defaultValue) {
+                if (isset($customFormData['custom_settings'][$key])) {
+                    $this->_defaults[$key] = $customFormData['custom_settings'][$key];
+                }
+            }
+        }
+    }
+
+    /**
      * This function sets the common fields on the quick form.
      *
      * @param array $customOptions the data provided by the hooks.

--- a/CRM/Appearancemodifier/Form/Event.php
+++ b/CRM/Appearancemodifier/Form/Event.php
@@ -11,6 +11,9 @@ use Civi\Api4\AppearancemodifierEvent;
  */
 class CRM_Appearancemodifier_Form_Event extends CRM_Appearancemodifier_Form_AbstractBase
 {
+    public const DEFAULT_CUSTOM_SETTINGS = [
+        'hide_form_title' => '',
+    ];
     private const EVENT_FIELDS = [
         'layout_handler',
         'background_color',
@@ -60,6 +63,8 @@ class CRM_Appearancemodifier_Form_Event extends CRM_Appearancemodifier_Form_Abst
             $this->_defaults[$key] = $this->modifiedEvent[$key];
         }
         parent::commondDefaultValues($this->modifiedEvent);
+        // default for the custom settings.
+        parent::customDefaultValues($this->modifiedEvent, self::DEFAULT_CUSTOM_SETTINGS);
         return $this->_defaults;
     }
 
@@ -91,7 +96,11 @@ class CRM_Appearancemodifier_Form_Event extends CRM_Appearancemodifier_Form_Abst
      */
     public function postProcess()
     {
-        parent::commonPostProcess(self::EVENT_FIELDS, $this->modifiedEvent['custom_settings']);
+        $customSettings = $this->modifiedEvent['custom_settings'];
+        foreach (self::DEFAULT_CUSTOM_SETTINGS as $key => $v) {
+            $customSettings[$key] = $this->_submitValues[$key];
+        }
+        parent::commonPostProcess(self::EVENT_FIELDS, $customSettings, self::DEFAULT_CUSTOM_SETTINGS);
         CRM_Core_Session::setStatus(E::ts('Data has been updated.'), 'Appearancemodifier', 'success', ['expires' => 5000,]);
 
         parent::postProcess();

--- a/CRM/Appearancemodifier/Form/Petition.php
+++ b/CRM/Appearancemodifier/Form/Petition.php
@@ -90,7 +90,6 @@ class CRM_Appearancemodifier_Form_Petition extends CRM_Appearancemodifier_Form_A
         );
         $this->add('textarea', 'petition_message', E::ts('Petition message'), ['rows' => '4', 'cols' => '60'], false);
         $this->add('checkbox', 'disable_petition_message_edit', E::ts('Disable edit'), [], false);
-        $this->add('checkbox', 'hide_form_title', E::ts('Hide form title'), [], false);
         $this->add('text', 'target_number_of_signers', E::ts('Target number of signers'), [], false);
         $this->add('checkbox', 'custom_social_box', E::ts('Custom social box'), [], false);
         $this->add('text', 'external_share_url', E::ts('External url to share'), [], false);

--- a/CRM/Appearancemodifier/Form/Petition.php
+++ b/CRM/Appearancemodifier/Form/Petition.php
@@ -10,6 +10,10 @@ use Civi\Api4\AppearancemodifierPetition;
  */
 class CRM_Appearancemodifier_Form_Petition extends CRM_Appearancemodifier_Form_AbstractBase
 {
+    public const DEFAULT_CUSTOM_SETTINGS = [
+        'hide_form_title' => '',
+        'disable_petition_message_edit' => ''
+    ];
     private const PETITION_FIELDS = [
         'layout_handler',
         'background_color',
@@ -63,10 +67,8 @@ class CRM_Appearancemodifier_Form_Petition extends CRM_Appearancemodifier_Form_A
             $this->_defaults[$key] = $this->modifiedPetition[$key];
         }
         parent::commondDefaultValues($this->modifiedPetition);
-        // default for the petition message edition.
-        if ($this->modifiedPetition['custom_settings'] !== null && isset($this->modifiedPetition['custom_settings']['disable_petition_message_edit'])) {
-            $this->_defaults['disable_petition_message_edit'] = $this->modifiedPetition['custom_settings']['disable_petition_message_edit'];
-        }
+        // default for the custom settings.
+        parent::customDefaultValues($this->modifiedPetition, self::DEFAULT_CUSTOM_SETTINGS);
         return $this->_defaults;
     }
 
@@ -88,6 +90,7 @@ class CRM_Appearancemodifier_Form_Petition extends CRM_Appearancemodifier_Form_A
         );
         $this->add('textarea', 'petition_message', E::ts('Petition message'), ['rows' => '4', 'cols' => '60'], false);
         $this->add('checkbox', 'disable_petition_message_edit', E::ts('Disable edit'), [], false);
+        $this->add('checkbox', 'hide_form_title', E::ts('Hide form title'), [], false);
         $this->add('text', 'target_number_of_signers', E::ts('Target number of signers'), [], false);
         $this->add('checkbox', 'custom_social_box', E::ts('Custom social box'), [], false);
         $this->add('text', 'external_share_url', E::ts('External url to share'), [], false);
@@ -104,8 +107,10 @@ class CRM_Appearancemodifier_Form_Petition extends CRM_Appearancemodifier_Form_A
     public function postProcess()
     {
         $customSettings = $this->modifiedPetition['custom_settings'];
-        $customSettings['disable_petition_message_edit'] = $this->_submitValues['disable_petition_message_edit'];
-        parent::commonPostProcess(self::PETITION_FIELDS, $customSettings, ['disable_petition_message_edit' => '']);
+        foreach (self::DEFAULT_CUSTOM_SETTINGS as $key => $v) {
+            $customSettings[$key] = $this->_submitValues[$key];
+        }
+        parent::commonPostProcess(self::PETITION_FIELDS, $customSettings, self::DEFAULT_CUSTOM_SETTINGS);
         CRM_Core_Session::setStatus(E::ts('Data has been updated.'), 'Appearancemodifier', 'success', ['expires' => 5000,]);
 
         parent::postProcess();

--- a/CRM/Appearancemodifier/Form/Profile.php
+++ b/CRM/Appearancemodifier/Form/Profile.php
@@ -11,6 +11,9 @@ use Civi\Api4\AppearancemodifierProfile;
  */
 class CRM_Appearancemodifier_Form_Profile extends CRM_Appearancemodifier_Form_AbstractBase
 {
+    public const DEFAULT_CUSTOM_SETTINGS = [
+        'hide_form_title' => '',
+    ];
     private const PROFILE_FIELDS = [
         'layout_handler',
         'background_color',
@@ -59,6 +62,8 @@ class CRM_Appearancemodifier_Form_Profile extends CRM_Appearancemodifier_Form_Ab
             $this->_defaults[$key] = $this->modifiedProfile[$key];
         }
         parent::commondDefaultValues($this->modifiedProfile);
+        // default for the custom settings.
+        parent::customDefaultValues($this->modifiedProfile, self::DEFAULT_CUSTOM_SETTINGS);
         return $this->_defaults;
     }
 
@@ -89,7 +94,11 @@ class CRM_Appearancemodifier_Form_Profile extends CRM_Appearancemodifier_Form_Ab
      */
     public function postProcess()
     {
-        parent::commonPostProcess(self::PROFILE_FIELDS, $this->modifiedProfile['custom_settings']);
+        $customSettings = $this->modifiedProfile['custom_settings'];
+        foreach (self::DEFAULT_CUSTOM_SETTINGS as $key => $v) {
+            $customSettings[$key] = $this->_submitValues[$key];
+        }
+        parent::commonPostProcess(self::PROFILE_FIELDS, $customSettings, self::DEFAULT_CUSTOM_SETTINGS);
         CRM_Core_Session::setStatus(E::ts('Data has been updated.'), 'Appearancemodifier', 'success', ['expires' => 5000,]);
 
         parent::postProcess();

--- a/CRM/Appearancemodifier/Service.php
+++ b/CRM/Appearancemodifier/Service.php
@@ -169,6 +169,9 @@ class CRM_Appearancemodifier_Service
         }
         if ($modifiedConfig !== null) {
             Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
+            if ($modifiedConfig['custom_settings'] !== null && $modifiedConfig['custom_settings']['hide_form_title'] === '1') {
+                Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/hiddentitle.css');
+            }
         }
     }
 
@@ -196,6 +199,9 @@ class CRM_Appearancemodifier_Service
             $handler->setStyleSheets();
         }
         Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
+        if ($modifiedProfile['custom_settings'] !== null && $modifiedProfile['custom_settings']['hide_form_title'] === '1') {
+            Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/hiddentitle.css');
+        }
     }
 
     /**
@@ -234,6 +240,9 @@ class CRM_Appearancemodifier_Service
         }
         if ($modifiedConfig !== null) {
             Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
+            if ($modifiedConfig['custom_settings'] !== null && $modifiedConfig['custom_settings']['hide_form_title'] === '1') {
+                Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/hiddentitle.css');
+            }
         }
     }
 

--- a/CRM/Appearancemodifier/Service.php
+++ b/CRM/Appearancemodifier/Service.php
@@ -138,35 +138,36 @@ class CRM_Appearancemodifier_Service
      */
     public static function pageRun(&$page): void
     {
+        $modifiedConfig = null;
         if ($page->getVar('_name') == 'CRM_Campaign_Page_Petition_ThankYou') {
-            $modifiedPetition = AppearancemodifierPetition::get(false)
+            $modifiedConfig = AppearancemodifierPetition::get(false)
                 ->addWhere('survey_id', '=', $page->getVar('petition')['id'])
                 ->execute()
                 ->first();
-            if ($modifiedPetition['layout_handler'] !== null) {
-                $handler = new $modifiedPetition['layout_handler']('CRM_Campaign_Page_Petition_ThankYou');
+            if ($modifiedConfig['layout_handler'] !== null) {
+                $handler = new $modifiedConfig['layout_handler']('CRM_Campaign_Page_Petition_ThankYou');
                 $handler->setStyleSheets();
             }
-            Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
         } elseif ($page->getVar('_name') == 'CRM_Event_Page_EventInfo') {
-            $modifiedEvent = AppearancemodifierEvent::get(false)
+            $modifiedConfig = AppearancemodifierEvent::get(false)
                 ->addWhere('event_id', '=', $page->getVar('_id'))
                 ->execute()
                 ->first();
-            if ($modifiedEvent['layout_handler'] !== null) {
-                $handler = new $modifiedEvent['layout_handler']('CRM_Event_Page_EventInfo');
+            if ($modifiedConfig['layout_handler'] !== null) {
+                $handler = new $modifiedConfig['layout_handler']('CRM_Event_Page_EventInfo');
                 $handler->setStyleSheets();
             }
-            Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
         } elseif ($page->getVar('_name') == 'CRM_Profile_Page_View') {
-            $modifiedProfile = AppearancemodifierProfile::get(false)
+            $modifiedConfig = AppearancemodifierProfile::get(false)
                 ->addWhere('uf_group_id', '=', $page->getVar('_gid'))
                 ->execute()
                 ->first();
-            if ($modifiedProfile['layout_handler'] !== null) {
-                $handler = new $modifiedProfile['layout_handler']('CRM_Profile_Page_View');
+            if ($modifiedConfig['layout_handler'] !== null) {
+                $handler = new $modifiedConfig['layout_handler']('CRM_Profile_Page_View');
                 $handler->setStyleSheets();
             }
+        }
+        if ($modifiedConfig !== null) {
             Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
         }
     }
@@ -211,25 +212,27 @@ class CRM_Appearancemodifier_Service
             'CRM_Event_Form_Registration_Confirm',
             'CRM_Event_Form_Registration_ThankYou',
         ];
+        $modifiedConfig = null;
         if ($formName === 'CRM_Campaign_Form_Petition_Signature') {
-            $modifiedPetition = AppearancemodifierPetition::get(false)
+            $modifiedConfig = AppearancemodifierPetition::get(false)
                 ->addWhere('survey_id', '=', $form->getVar('_surveyId'))
                 ->execute()
                 ->first();
-            if ($modifiedPetition['layout_handler'] !== null) {
-                $handler = new $modifiedPetition['layout_handler']($formName);
+            if ($modifiedConfig['layout_handler'] !== null) {
+                $handler = new $modifiedConfig['layout_handler']($formName);
                 $handler->setStyleSheets();
             }
-            Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
         } elseif (array_search($formName, $eventFormNames) !== false) {
-            $modifiedEvent = AppearancemodifierEvent::get(false)
+            $modifiedConfig = AppearancemodifierEvent::get(false)
                 ->addWhere('event_id', '=', $form->getVar('_eventId'))
                 ->execute()
                 ->first();
-            if ($modifiedEvent['layout_handler'] !== null) {
-                $handler = new $modifiedEvent['layout_handler']($formName);
+            if ($modifiedConfig['layout_handler'] !== null) {
+                $handler = new $modifiedConfig['layout_handler']($formName);
                 $handler->setStyleSheets();
             }
+        }
+        if ($modifiedConfig !== null) {
             Civi::resources()->addStyleFile(E::LONG_NAME, 'assets/css/appearancemodifier.css');
         }
     }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The form customization is based on additional settings that could be reached fro
 - Consent Field Behaviour - It provides 3 options. Default (opt-out consent fields), invert (opt-in consent fields), submit implied (set do\_not\_phone and is\_opt\_out to false after form submit).
 - Add placeholders - If checked, the text inputs will contain placeholder attributes. The value of the placeholder will be the same as the label of the text input.
 - Hide text input labels - Only applied when the Add placeholder also applied. If checked the labels of the text inputs will be hidden.
+- Hide form title - If this flag is set, the titles will be hidden on the forms and pages.
 
 ### Consent activity extension
 

--- a/assets/css/hiddentitle.css
+++ b/assets/css/hiddentitle.css
@@ -1,0 +1,7 @@
+/* Page header has to be hidden */
+.adminimal h1.page-title,
+div#branding h1.page-title,
+div#block-stark-page-title h1,
+h1.page-title {
+    display: none;
+}

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/appearancemodifier/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-11-08</releaseDate>
-    <version>3.4.1</version>
+    <releaseDate>2021-11-11</releaseDate>
+    <version>3.5.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/templates/CRM/Appearancemodifier/Form/CommonFormItems.tpl
+++ b/templates/CRM/Appearancemodifier/Form/CommonFormItems.tpl
@@ -1,0 +1,56 @@
+{crmScope extensionKey='appearancemodifier'}
+<h3>{ts}General Settings{/ts}</h3>
+<table class="form-layout">
+    <tr>
+        <td class="label">{$form.preset_handler.label}</td>
+        <td class="content">{$form.preset_handler.html}<br/>
+            <span class="description">{ts}Use the saved settings or customize from scratch.{/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.layout_handler.label}</td>
+        <td class="content">{$form.layout_handler.html}<br/>
+            <span class="description">{ts}Layout manipulation.{/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.background_color.label}</td>
+        <td class="content">{$form.background_color.html}<br/>
+            <span class="label">{$form.original_color.label}{$form.original_color.html}</span><br/>
+            <span class="label">{$form.transparent_background.label}{$form.transparent_background.html}</span><br/>
+            <span class="description">{ts}Background color manipulation.{/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.font_color.label}</td>
+        <td class="content">{$form.font_color.html}<br/>
+            <span class="label">{$form.original_font_color.label}{$form.original_font_color.html}</span><br/>
+            <span class="description">{ts}Font color manipulation.{/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.consent_field_behaviour.label}</td>
+        <td class="content">{$form.consent_field_behaviour.html}<br/>
+            <span class="description">{ts}Set the behaviour of consent fields. (opt-out vs opt in vs implied){/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.add_placeholder.label}</td>
+        <td class="content">{$form.add_placeholder.html}<br/>
+            <span class="description">{ts}Add placeholders to the text inputs.{/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.hide_form_labels.label}</td>
+        <td class="content">{$form.hide_form_labels.html}<br/>
+            <span class="description">{ts}Hide the labels of the text inputs on the petition form. Applied only if the placeholders are added.{/ts}</span>
+        </td>
+    </tr>
+    <tr>
+        <td class="label">{$form.hide_form_title.label}</td>
+        <td class="content">{$form.hide_form_title.html}<br/>
+            <span class="description">{ts}Hide the title of the form.{/ts}</span>
+        </td>
+    </tr>
+</table>
+{/crmScope}

--- a/templates/CRM/Appearancemodifier/Form/ConsentActivityItems.tpl
+++ b/templates/CRM/Appearancemodifier/Form/ConsentActivityItems.tpl
@@ -1,0 +1,11 @@
+{crmScope extensionKey='appearancemodifier'}
+<h3>{ts}Consent Activity Settings{/ts}</h3>
+<table class="form-layout">
+{foreach from=$consentActivityFieldNames item=FieldName}
+    <tr>
+        <td class="label">{$form.$FieldName.label}</td>
+        <td class="content">{$form.$FieldName.html}</td>
+    </tr>
+{/foreach}
+</table>
+{/crmScope}

--- a/templates/CRM/Appearancemodifier/Form/Event.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Event.tpl
@@ -1,51 +1,8 @@
 {crmScope extensionKey='appearancemodifier'}
 <div class="crm-block crm-form-block">
+    {include file="CRM/Appearancemodifier/Form/CommonFormItems.tpl"}
+    <h3>{ts}Event Settings{/ts}</h3>
     <table class="form-layout">
-        <tr>
-            <td class="label">{$form.preset_handler.label}</td>
-            <td class="content">{$form.preset_handler.html}<br/>
-                <span class="description">{ts}Use the saved settings or customize from scratch.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.layout_handler.label}</td>
-            <td class="content">{$form.layout_handler.html}<br/>
-                <span class="description">{ts}Layout manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.background_color.label}</td>
-            <td class="content">{$form.background_color.html}<br/>
-                <span class="label">{$form.original_color.label}{$form.original_color.html}</span><br/>
-                <span class="label">{$form.transparent_background.label}{$form.transparent_background.html}</span><br/>
-                <span class="description">{ts}Background color manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.font_color.label}</td>
-            <td class="content">{$form.font_color.html}<br/>
-                <span class="label">{$form.original_font_color.label}{$form.original_font_color.html}</span><br/>
-                <span class="description">{ts}Font color manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.consent_field_behaviour.label}</td>
-            <td class="content">{$form.consent_field_behaviour.html}<br/>
-                <span class="description">{ts}Set the behaviour of consent fields. (opt-out vs opt in vs implied){/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.add_placeholder.label}</td>
-            <td class="content">{$form.add_placeholder.html}<br/>
-                <span class="description">{ts}Add placeholders to the text inputs.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.hide_form_labels.label}</td>
-            <td class="content">{$form.hide_form_labels.html}<br/>
-                <span class="description">{ts}Hide the labels of the text inputs on the event form. Applied only if the placeholders are added.{/ts}</span>
-            </td>
-        </tr>
         <tr>
             <td class="label">{$form.custom_social_box.label}</td>
             <td class="content">{$form.custom_social_box.html}<br/>
@@ -58,13 +15,10 @@
                 <span class="description">{ts}The external url that will be shared from the custom social box.{/ts}</span>
             </td>
         </tr>
-{foreach from=$consentActivityFieldNames item=FieldName}
-        <tr>
-            <td class="label">{$form.$FieldName.label}</td>
-            <td class="content">{$form.$FieldName.html}</td>
-        </tr>
-{/foreach}
     </table>
+{if $consentActivityFieldNames|@count gt 0}
+    {include file="CRM/Appearancemodifier/Form/ConsentActivityItems.tpl"}
+{/if}
     <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/templates/CRM/Appearancemodifier/Form/Petition.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Petition.tpl
@@ -1,61 +1,12 @@
 {crmScope extensionKey='appearancemodifier'}
 <div class="crm-block crm-form-block">
+    {include file="CRM/Appearancemodifier/Form/CommonFormItems.tpl"}
+    <h3>{ts}Petition Settings{/ts}</h3>
     <table class="form-layout">
-        <tr>
-            <td class="label">{$form.preset_handler.label}</td>
-            <td class="content">{$form.preset_handler.html}<br/>
-                <span class="description">{ts}Use the saved settings or customize from scratch.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.layout_handler.label}</td>
-            <td class="content">{$form.layout_handler.html}<br/>
-                <span class="description">{ts}Layout manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.background_color.label}</td>
-            <td class="content">{$form.background_color.html}<br/>
-                <span class="label">{$form.original_color.label}{$form.original_color.html}</span><br/>
-                <span class="label">{$form.transparent_background.label}{$form.transparent_background.html}</span><br/>
-                <span class="description">{ts}Background color manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.font_color.label}</td>
-            <td class="content">{$form.font_color.html}<br/>
-                <span class="label">{$form.original_font_color.label}{$form.original_font_color.html}</span><br/>
-                <span class="description">{ts}Font color manipulation.{/ts}</span>
-            </td>
-        </tr>
         <tr>
             <td class="label">{$form.additional_note.label}</td>
             <td class="content">{$form.additional_note.html}<br/>
                 <span class="description">{ts}The text after the submit button.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.consent_field_behaviour.label}</td>
-            <td class="content">{$form.consent_field_behaviour.html}<br/>
-                <span class="description">{ts}Set the behaviour of consent fields. (opt-out vs opt in vs implied){/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.add_placeholder.label}</td>
-            <td class="content">{$form.add_placeholder.html}<br/>
-                <span class="description">{ts}Add placeholders to the text inputs.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.hide_form_labels.label}</td>
-            <td class="content">{$form.hide_form_labels.html}<br/>
-                <span class="description">{ts}Hide the labels of the text inputs on the petition form. Applied only if the placeholders are added.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.hide_form_title.label}</td>
-            <td class="content">{$form.hide_form_title.html}<br/>
-                <span class="description">{ts}Hide the title of the form.{/ts}</span>
             </td>
         </tr>
         <tr>
@@ -84,13 +35,10 @@
                 <span class="description">{ts}The external url that will be shared from the custom social box.{/ts}</span>
             </td>
         </tr>
-{foreach from=$consentActivityFieldNames item=FieldName}
-        <tr>
-            <td class="label">{$form.$FieldName.label}</td>
-            <td class="content">{$form.$FieldName.html}</td>
-        </tr>
-{/foreach}
     </table>
+{if $consentActivityFieldNames|@count gt 0}
+    {include file="CRM/Appearancemodifier/Form/ConsentActivityItems.tpl"}
+{/if}
     <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/templates/CRM/Appearancemodifier/Form/Petition.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Petition.tpl
@@ -53,6 +53,12 @@
             </td>
         </tr>
         <tr>
+            <td class="label">{$form.hide_form_title.label}</td>
+            <td class="content">{$form.hide_form_title.html}<br/>
+                <span class="description">{ts}Hide the title of the form.{/ts}</span>
+            </td>
+        </tr>
+        <tr>
             <td class="label">{$form.petition_message.label}</td>
             <td class="content">{$form.petition_message.html}<br/>
                 <span class="label">{$form.disable_petition_message_edit.label}{$form.disable_petition_message_edit.html}</span><br/>

--- a/templates/CRM/Appearancemodifier/Form/Profile.tpl
+++ b/templates/CRM/Appearancemodifier/Form/Profile.tpl
@@ -1,64 +1,18 @@
 {crmScope extensionKey='appearancemodifier'}
 <div class="crm-block crm-form-block">
+    {include file="CRM/Appearancemodifier/Form/CommonFormItems.tpl"}
+    <h3>{ts}Profile Settings{/ts}</h3>
     <table class="form-layout">
-        <tr>
-            <td class="label">{$form.preset_handler.label}</td>
-            <td class="content">{$form.preset_handler.html}<br/>
-                <span class="description">{ts}Use the saved settings or customize from scratch.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.layout_handler.label}</td>
-            <td class="content">{$form.layout_handler.html}<br/>
-                <span class="description">{ts}Layout manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.background_color.label}</td>
-            <td class="content">{$form.background_color.html}<br/>
-                <span class="label">{$form.original_color.label}{$form.original_color.html}</span><br/>
-                <span class="label">{$form.transparent_background.label}{$form.transparent_background.html}</span><br/>
-                <span class="description">{ts}Background color manipulation.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.font_color.label}</td>
-            <td class="content">{$form.font_color.html}<br/>
-                <span class="label">{$form.original_font_color.label}{$form.original_font_color.html}</span><br/>
-                <span class="description">{ts}Font color manipulation.{/ts}</span>
-            </td>
-        </tr>
         <tr>
             <td class="label">{$form.additional_note.label}</td>
             <td class="content">{$form.additional_note.html}<br/>
                 <span class="description">{ts}The text after the submit button.{/ts}</span>
             </td>
         </tr>
-        <tr>
-            <td class="label">{$form.consent_field_behaviour.label}</td>
-            <td class="content">{$form.consent_field_behaviour.html}<br/>
-                <span class="description">{ts}Set the behaviour of consent fields. (opt-out vs opt in vs implied){/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.add_placeholder.label}</td>
-            <td class="content">{$form.add_placeholder.html}<br/>
-                <span class="description">{ts}Add placeholders to the text inputs.{/ts}</span>
-            </td>
-        </tr>
-        <tr>
-            <td class="label">{$form.hide_form_labels.label}</td>
-            <td class="content">{$form.hide_form_labels.html}<br/>
-                <span class="description">{ts}Hide the labels of the text inputs on the profile form. Applied only if the placeholders are added.{/ts}</span>
-            </td>
-        </tr>
-{foreach from=$consentActivityFieldNames item=FieldName}
-        <tr>
-            <td class="label">{$form.$FieldName.label}</td>
-            <td class="content">{$form.$FieldName.html}</td>
-        </tr>
-{/foreach}
     </table>
+{if $consentActivityFieldNames|@count gt 0}
+    {include file="CRM/Appearancemodifier/Form/ConsentActivityItems.tpl"}
+{/if}
     <div class="crm-submit-buttons">
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/tests/phpunit/CRM/Appearancemodifier/Form/EventConsentTest.php
+++ b/tests/phpunit/CRM/Appearancemodifier/Form/EventConsentTest.php
@@ -258,6 +258,7 @@ class CRM_Appearancemodifier_Form_EventConsentTest extends CRM_Appearancemodifie
             'hide_form_labels' => '',
             'add_placeholder' => '',
             'preset_handler' => '',
+            'hide_form_title' => '',
             'consentactivity_custom_'.$customField['id'] => '1',
         ]);
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');

--- a/tests/phpunit/CRM/Appearancemodifier/Form/EventTest.php
+++ b/tests/phpunit/CRM/Appearancemodifier/Form/EventTest.php
@@ -211,6 +211,7 @@ class CRM_Appearancemodifier_Form_EventTest extends \PHPUnit\Framework\TestCase 
         $_POST['hide_form_labels'] = '';
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = '';
+        $_POST['hide_form_title'] = '';
         $form = new CRM_Appearancemodifier_Form_Event();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');
@@ -244,6 +245,7 @@ class CRM_Appearancemodifier_Form_EventTest extends \PHPUnit\Framework\TestCase 
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = 'DummyEventPresetProviderClass';
         $_POST['consent_field_behaviour'] = 'default';
+        $_POST['hide_form_title'] = '';
         $form = new CRM_Appearancemodifier_Form_Event();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');
@@ -278,6 +280,7 @@ class CRM_Appearancemodifier_Form_EventTest extends \PHPUnit\Framework\TestCase 
         $_POST['hide_form_labels'] = '';
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = '';
+        $_POST['hide_form_title'] = '';
         $form = new CRM_Appearancemodifier_Form_Event();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');

--- a/tests/phpunit/CRM/Appearancemodifier/Form/PetitionConsentTest.php
+++ b/tests/phpunit/CRM/Appearancemodifier/Form/PetitionConsentTest.php
@@ -267,6 +267,7 @@ class CRM_Appearancemodifier_Form_PetitionConsentTest extends CRM_Appearancemodi
             'hide_form_labels' => '',
             'add_placeholder' => '',
             'preset_handler' => '',
+            'hide_form_title' => '',
             'consentactivity_custom_'.$customField['id'] => '1',
         ]);
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');

--- a/tests/phpunit/CRM/Appearancemodifier/Form/PetitionTest.php
+++ b/tests/phpunit/CRM/Appearancemodifier/Form/PetitionTest.php
@@ -237,6 +237,7 @@ class CRM_Appearancemodifier_Form_PetitionTest extends \PHPUnit\Framework\TestCa
             'hide_form_labels' => '',
             'add_placeholder' => '',
             'preset_handler' => '',
+            'hide_form_title' => '',
         ]);
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');
@@ -277,6 +278,7 @@ class CRM_Appearancemodifier_Form_PetitionTest extends \PHPUnit\Framework\TestCa
             'hide_form_labels' => '',
             'add_placeholder' => '',
             'preset_handler' => 'DummyPetitionPresetProviderClass',
+            'hide_form_title' => '',
         ]);
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');
@@ -319,6 +321,7 @@ class CRM_Appearancemodifier_Form_PetitionTest extends \PHPUnit\Framework\TestCa
             'hide_form_labels' => '',
             'add_placeholder' => '',
             'preset_handler' => '',
+            'hide_form_title' => '',
         ]);
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');

--- a/tests/phpunit/CRM/Appearancemodifier/Form/ProfileConsentTest.php
+++ b/tests/phpunit/CRM/Appearancemodifier/Form/ProfileConsentTest.php
@@ -195,6 +195,7 @@ class CRM_Appearancemodifier_Form_ProfileConsentTest extends CRM_Appearancemodif
         $_POST['hide_form_labels'] = '';
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = '';
+        $_POST['hide_form_title'] = '';
         $_POST['consentactivity_custom_'.$customField['id']] = '1';
         $form = new CRM_Appearancemodifier_Form_Profile();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');

--- a/tests/phpunit/CRM/Appearancemodifier/Form/ProfileTest.php
+++ b/tests/phpunit/CRM/Appearancemodifier/Form/ProfileTest.php
@@ -199,6 +199,7 @@ class CRM_Appearancemodifier_Form_ProfileTest extends \PHPUnit\Framework\TestCas
         $_POST['hide_form_labels'] = '';
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = '';
+        $_POST['hide_form_title'] = '';
         $form = new CRM_Appearancemodifier_Form_Profile();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');
@@ -229,6 +230,7 @@ class CRM_Appearancemodifier_Form_ProfileTest extends \PHPUnit\Framework\TestCas
         $_POST['hide_form_labels'] = '';
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = 'DummyProfilePresetProviderClass';
+        $_POST['hide_form_title'] = '';
         $form = new CRM_Appearancemodifier_Form_Profile();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');
@@ -261,6 +263,7 @@ class CRM_Appearancemodifier_Form_ProfileTest extends \PHPUnit\Framework\TestCas
         $_POST['hide_form_labels'] = '';
         $_POST['add_placeholder'] = '';
         $_POST['preset_handler'] = '';
+        $_POST['hide_form_title'] = '';
         $form = new CRM_Appearancemodifier_Form_Profile();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
         self::assertEmpty($form->postProcess(), 'postProcess supposed to be empty.');


### PR DESCRIPTION
Implement option to hide titles on the public from and pages.
- new custom_setting entry and update functionality for the hide-title
- refactor - move the common ui elements to common files
- the hide-title option has been added to the ui (profile, petition, event)
- css file that is added as resource when the config is set to hidden title
- test case updates