### PR TITLE
send.js: use offsetHeight

### DIFF
--- a/assets/js/size.js
+++ b/assets/js/size.js
@@ -22,7 +22,7 @@ function sendResizeMessage() {
     let bodyElement = window.self.document.querySelector('body');
     let message = {
         type: "resize",
-        height: bodyElement.clientHeight,
+        height: bodyElement.offsetHeight,
     };
     let to = allowedMessageReceiver || '*';
     window.self.parent.postMessage(message, to);

--- a/assets/js/size.js
+++ b/assets/js/size.js
@@ -30,13 +30,13 @@ function sendResizeMessage() {
 
 // The resize event handler function.
 function resizeEventHandler() {
-    setTimeout(sendResizeMessage, 1000);
+    setTimeout(sendResizeMessage, 200);
 }
 
 // onload
 (function () {
     if (inIframe()) {
-        setTimeout(sendResizeMessage, 1000);
+        setTimeout(sendResizeMessage, 200);
         window.self.addEventListener('resize', resizeEventHandler);
     }
 })();

--- a/assets/js/size.js
+++ b/assets/js/size.js
@@ -1,22 +1,23 @@
-/*
- * On case of the profile is loaded in iframe, the height of the content
+/**
+ * In case of the profile is loaded in iframe, the height of the content
  * has to be passed to the parent js, to be able to update the iframe
- * container height. The communication is based on messages. On case of
+ * container height. The communication is based on messages. In case of
  * onload event or resize event, it sends a message to the parent window.
  * The message contains a type, that has to be resize, and a height that
  * stores the value of the current height.
- * Event listener is not necessary as we don't expecect replies or any
+ * Event listener is not necessary as we don't expect replies or any
  * other kind of messages from the parent.
- * */
+ */
 // It returns true, if the self window object is NOT the top level window object.
-function inIframe () {
+function inIframe() {
     try {
         return window.self !== window.top;
     } catch (e) {
         return true;
     }
 }
-// It sends the reize message to the parent iframe.
+
+// It sends the resize message to the parent iframe.
 function sendResizeMessage() {
     let bodyElement = window.self.document.querySelector('body');
     let message = {
@@ -26,12 +27,14 @@ function sendResizeMessage() {
     let to = allowedMessageReceiver || '*';
     window.self.parent.postMessage(message, to);
 }
+
 // The resize event handler function.
 function resizeEventHandler() {
     setTimeout(sendResizeMessage, 1000);
 }
+
 // onload
-(function() {
+(function () {
     if (inIframe()) {
         setTimeout(sendResizeMessage, 1000);
         window.self.addEventListener('resize', resizeEventHandler);

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/appearancemodifier/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2022-04-05</releaseDate>
-    <version>3.9.1</version>
+    <releaseDate>2022-04-15</releaseDate>
+    <version>3.9.2</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
When sending the height to parent use `offsetHeight` instead of `clientHeight` as it includes padding and borders as well.