### PR TITLE
Add form-level killswitch

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -54,6 +54,23 @@ function hook_civicrm_appearancemodifierEventSettings(&$handlers)
 
 The form customization is based on additional settings that could be reached from a new menu link. The additional settings are stored in managed entities.
 
+Additionally, customization can be enabled/disabled globally for each form type. For this use the following constant settings in `civicrm.settings.php`:
+
+```php
+// Disable Appearance Modifier for petitions but enable for profiles and events
+// Note: the default value is true for all form types
+define('CIVICRM_RC_APPEARANCEMODIFIER_ENABLED', [
+    'profile' => true,
+    'petition' => false,
+    'event' => true,
+]);
+
+// Enabled types can be omitted, as it defaults to true, so the above is equivalent to:
+define('CIVICRM_RC_APPEARANCEMODIFIER_ENABLED', [
+    'petition' => false,
+]);
+```
+
 ### General settings
 
 - Is Active - Kill switch for the entity. This is off by default, you have to enable it to apply the settings on the form.

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/appearancemodifier/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2025-09-02</releaseDate>
-    <version>4.5.0</version>
+    <releaseDate>2025-09-03</releaseDate>
+    <version>4.6.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.76</ver>


### PR DESCRIPTION
Customization can be enabled/disabled globally for each form type (profile, petition, event).